### PR TITLE
New metadata format usable for OAI-PMH transport from Digitool

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/dc_transport.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/dc_transport.xsl
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- 
+
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+	Developed by DSpace @ Lyncode <dspace@lyncode.com>
+	
+	> http://www.openarchives.org/OAI/2.0/oai_dc.xsd
+
+ -->
+<xsl:stylesheet 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:doc="http://www.lyncode.com/xoai"
+	version="1.0">
+	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
+	
+	<xsl:template match="/">
+		<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" 
+			xmlns:dc="http://purl.org/dc/elements/1.1/" 
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+			xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+			<!-- dc.title -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
+				<dc:title><xsl:value-of select="." /></dc:title>
+			</xsl:for-each>
+			<!-- dc.title.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:title><xsl:value-of select="." /></dc:title>
+			</xsl:for-each>
+			<!-- dc.creator -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='creator']/doc:element/doc:field[@name='value']">
+				<dc:creator><xsl:value-of select="." /></dc:creator>
+			</xsl:for-each>
+			<!-- dc.contributor.author -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
+				<dc:creator><xsl:value-of select="." /></dc:creator>
+			</xsl:for-each>
+			<!-- dc.contributor.* (!author) -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name!='author']/doc:element/doc:field[@name='value']">
+				<dc:contributor><xsl:value-of select="." /></dc:contributor>
+			</xsl:for-each>
+			<!-- dc.contributor -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element/doc:field[@name='value']">
+				<dc:contributor><xsl:value-of select="." /></dc:contributor>
+			</xsl:for-each>
+			<!-- dc.subject -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:field[@name='value']">
+				<dc:subject><xsl:value-of select="." /></dc:subject>
+			</xsl:for-each>
+			<!-- dc.subject.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:subject><xsl:value-of select="." /></dc:subject>
+			</xsl:for-each>
+			<!-- dc.description -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element/doc:field[@name='value']">
+				<dc:description><xsl:value-of select="." /></dc:description>
+			</xsl:for-each>
+			<!-- dc.description.* (not provenance)-->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name!='provenance']/doc:element/doc:field[@name='value']">
+				<dc:description><xsl:value-of select="." /></dc:description>
+			</xsl:for-each>
+			<!-- dc.description.provenance -->
+
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='provenance']/doc:element/doc:field[@name='value']">
+				<dc:description.provenance><xsl:value-of select="." /></dc:description.provenance>
+			</xsl:for-each>
+			<!-- dc.date -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element/doc:field[@name='value']">
+				<dc:date><xsl:value-of select="." /></dc:date>
+			</xsl:for-each>
+			<!-- dc.date.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:date><xsl:value-of select="." /></dc:date>
+			</xsl:for-each>
+			<!-- dc.type -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:field[@name='value']">
+				<dc:type><xsl:value-of select="." /></dc:type>
+			</xsl:for-each>
+			<!-- dc.type.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:type><xsl:value-of select="." /></dc:type>
+			</xsl:for-each>
+			<!-- dc.identifier -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element/doc:field[@name='value']">
+				<dc:identifier><xsl:value-of select="." /></dc:identifier>
+			</xsl:for-each>
+			<!-- dc.identifier.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:identifier><xsl:value-of select="." /></dc:identifier>
+			</xsl:for-each>
+			<!-- dc.language -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:field[@name='value']">
+				<dc:language><xsl:value-of select="." /></dc:language>
+			</xsl:for-each>
+			<!-- dc.language.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:language><xsl:value-of select="." /></dc:language>
+			</xsl:for-each>
+			<!-- dc.relation -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:field[@name='value']">
+				<dc:relation><xsl:value-of select="." /></dc:relation>
+			</xsl:for-each>
+			<!-- dc.relation.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:relation><xsl:value-of select="." /></dc:relation>
+			</xsl:for-each>
+			<!-- dc.rights -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']">
+				<dc:rights><xsl:value-of select="." /></dc:rights>
+			</xsl:for-each>
+			<!-- dc.rights.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:rights><xsl:value-of select="." /></dc:rights>
+			</xsl:for-each>
+			<!-- dc.format -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:field[@name='value']">
+				<dc:format><xsl:value-of select="." /></dc:format>
+			</xsl:for-each>
+			<!-- dc.format.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='format']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:format><xsl:value-of select="." /></dc:format>
+			</xsl:for-each>
+			<!-- ? -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
+				<dc:format><xsl:value-of select="." /></dc:format>
+			</xsl:for-each>
+			<!-- dc.coverage -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
+				<dc:coverage><xsl:value-of select="." /></dc:coverage>
+			</xsl:for-each>
+			<!-- dc.coverage.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:coverage><xsl:value-of select="." /></dc:coverage>
+			</xsl:for-each>
+			<!-- dc.publisher -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
+				<dc:publisher><xsl:value-of select="." /></dc:publisher>
+			</xsl:for-each>
+			<!-- dc.publisher.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='publisher']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:publisher><xsl:value-of select="." /></dc:publisher>
+			</xsl:for-each>
+			<!-- dc.source -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:field[@name='value']">
+				<dc:source><xsl:value-of select="." /></dc:source>
+			</xsl:for-each>
+			<!-- dc.source.* -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='source']/doc:element/doc:element/doc:field[@name='value']">
+				<dc:source><xsl:value-of select="." /></dc:source>
+			</xsl:for-each>
+		</oai_dc:dc>
+	</xsl:template>
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -30,7 +30,8 @@
             <Format ref="qdc"/>
             <Format ref="marc"/>
             <Format ref="uketd_dc"/>
-            <Format ref="uk_nusl"/>
+	    <Format ref="uk_nusl"/>
+	    <Format ref="dctransport"/>
 	    <Format ref="oai_uk_vufind"/>
 	    <Format ref="oai_dc_citations"/>
             <!--<Format ref="junii2" />-->
@@ -109,6 +110,12 @@
             <Namespace>http://www.openarchives.org/OAI/2.0/oai_dc/</Namespace>
             <SchemaLocation>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</SchemaLocation>
         </Format>
+        <Format id="dctransport">
+	    <Prefix>dc_transport</Prefix>
+	    <XSLT>metadataFormats/dc_transport.xsl</XSLT>
+	    <Namespace>http://www.openartchives.org/OAI/2.0/oai_dc/</Namespace>
+	    <SchemaLocation>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</SchemaLocation>
+	</Format>
         <Format id="mets">
             <Prefix>mets</Prefix>
             <XSLT>metadataFormats/mets.xsl</XSLT>

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -26,7 +26,7 @@ config.dir = ${dspace.dir}/config/crosswalks/oai
 description.file = ${dspace.dir}/config/crosswalks/oai/description.xml
 
 # Cache enabled?
-cache.enabled = true
+cache.enabled = false
 
 # Base Cache Directory
 cache.dir = ${dspace.dir}/var/oai


### PR DESCRIPTION
### Description

Added new metadata format based on oai_dc format usable for OAI-PMH transport from Digitool. New metadata format provides information about document's provenance (in field `<dc:description.provenance>` where information about original DTL identifier is stored.

Original DTL identifier is used to reference a base DTL object. Base DTL object can then be matched with newly created DSpace object.

This can be useful in many cases, e.g. when we are trying to add bistreams to "metadata-only" objects created by OAI-PMH harvest from Digitool, etc. 