### PR TITLE
FIX - UKUK DSpace Issue #10 - document types not translating correctly

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_theme/xsl/aspect/artifactbrowser/item-view-general-templates.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/ukuk_theme/xsl/aspect/artifactbrowser/item-view-general-templates.xsl
@@ -60,6 +60,7 @@
     </xsl:template>
 
     <!-- <JR> - 20. 2. 2017 -->
+    <!-- DC.TYPE -->
     <xsl:template name="itemSummaryView-DIM-general-work-type">
         <xsl:choose>
             <xsl:when test="$active-locale='en'">
@@ -69,6 +70,21 @@
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:choose>
+                            <xsl:when test="dim:field[@element='type']='bakalářská práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-bachelor-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='diplomová práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-diploma-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='rigorózní práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-rigo-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='dizertační práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-disert-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='habilitační práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-habi-th-item-view</i18n:text>
+                            </xsl:when>
                             <xsl:when test="dim:field[@element='type']">
                                 <xsl:value-of select="dim:field[@element='type']"/>
                             </xsl:when>
@@ -103,6 +119,21 @@
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:choose>
+                            <xsl:when test="dim:field[@element='type']='bakalářská práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-bachelor-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='diplomová práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-diploma-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='rigorózní práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-rigo-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='dizertační práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-disert-th-item-view</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='type']='habilitační práce'">
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-type-habi-th-item-view</i18n:text>
+                            </xsl:when>
                             <xsl:when test="dim:field[@element='type']">
                                 <xsl:value-of select="dim:field[@element='type']"/>
                             </xsl:when>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2298,11 +2298,11 @@
         <!--<AM> - 18.4.2017 - přidání výrazu pro afiliaci v item-view-->
         <message key="xmlui.dri2xhtml.METS-1.0.item-affiliation-item-view">Author's Affiliation</message>
 	<!--<JR> - 20. 2. 2017 - přidání výrazů pro jednotlivé typy dokumentů v item-view-->
-	<message key="xmlui.dri2xhtml.METS-1.0.item-type-bachelor-th-item-view">Bachelor Theses</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-type-diploma-th-item-view">Diploma Theses</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-type-rigo-th-item-view">Rigorous Work</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-type-disert-th-item-view">Disertation Theses</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-type-habi-th-item-view">Habilitation Work</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-type-bachelor-th-item-view">bachelor thesis</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-type-diploma-th-item-view">diploma thesis</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-type-rigo-th-item-view">rigorous thesis</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-type-disert-th-item-view">dissertation thesis</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-type-habi-th-item-view">habilitation thesis</message>
 	<!--<JR> - 21. 2. 2017 - přidání výrazu pro datum obhajoby v item-view-->
 	<message key="xmlui.dri2xhtml.METS-1.0.item-acceptance-date-item-view">Date of defense</message>
 	<!--<JR> - 21. 2. 2017 - přidání výrazu pro vedoucího práce  v item-view-->


### PR DESCRIPTION
* added XSLT to correctly translate theses document types, solution is however rather dirty. Better solution should be devised based on revisiting the existing metadata format used in the repository (see issue #73). 