### PR TITLE
SWORDv2 e-mail notification temporarily switched off

### DIFF
--- a/dspace/config/modules/swordv2-server.cfg
+++ b/dspace/config/modules/swordv2-server.cfg
@@ -437,7 +437,9 @@ multipart.entry-first = false
 # if the workflow gets started, should there be a notification
 # email sent
 #
-workflow.notify = true
+# <JR> - 18. 9. 2019 - Temporarily changed to false to avoid e-mail notification spam
+# when uploading large bulk of test data
+workflow.notify = false
 
 # when content is replaced, should the old version of the content be kept?  This
 # creates a copy of the ORIGINAL bundle with the name V_YYYY-MM-DD.X where YYYY-MM-DD


### PR DESCRIPTION
 to avoid e-mail spam when uploading large ammounts of test data