### PR TITLE
Feature/request copy helpdesk

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -122,6 +122,20 @@ mail.alert.recipient=
 #mail.registration.notify = email-address-here
 mail.registration.notify=
 
+#---------------------------------------------------------------#
+#----------------REQUEST ITEM CONFIGURATION---------------------#
+#---------------------------------------------------------------#
+
+# Configuration of request-item. Possible values:
+# all - Anonymous users can request an item
+# logged - Login is mandatory to request an item
+# empty/commented out - request-copy not allowed
+request.item.type = all
+# Helpdesk E-mail
+mail.helpdesk = ${mail.admin}
+# Should all Request Copy emails go to the helpdesk instead of the item submitter?
+request.item.helpdesk.override = true
+
 ########################
 # HANDLE CONFIGURATION #
 ########################

--- a/dspace/config/spring/api/requestitem.xml
+++ b/dspace/config/spring/api/requestitem.xml
@@ -19,8 +19,8 @@
 
     <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
 
-	<bean class="org.dspace.app.requestitem.RequestItemMetadataStrategy"
-		id="org.dspace.app.requestitem.RequestItemAuthorExtractor">
+    	<!--<bean class="org.dspace.app.requestitem.RequestItemMetadataStrategy"
+	id="org.dspace.app.requestitem.RequestItemAuthorExtractor">-->
 	<!-- 
 		Uncomment these properties if you want lookup in metadata the email and the name of the author to contact for request copy.
 		If you don't configure that or if the requested item doesn't have these metadata the submitter data are used as fail over
@@ -32,7 +32,6 @@
 	</bean>
 
     <!-- HelpDesk to instead get RequestItem emails-->
-    <!--<bean class="org.dspace.app.requestitem.RequestItemHelpdeskStrategy"
-        id="org.dspace.app.requestitem.RequestItemAuthorExtractor"></bean>-->
+    <bean class="org.dspace.app.requestitem.RequestItemHelpdeskStrategy" id="org.dspace.app.requestitem.RequestItemAuthorExtractor"></bean>
 
 </beans>


### PR DESCRIPTION
# Functionality overview

* when users submits a request for a copy of a private document, request details will be sent to DSpace administrators / helpdesk, not to the original submitter

## Prerequisities
* `mail.helpdesk` property has to be filled in (not empty or missing) in DSpace config file
* more information about configuration of this feature is available in the [DSpace documentation](https://wiki.lyrasis.org/display/DSDOC5x/Request+a+Copy)